### PR TITLE
fix rke cert manager issue

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -76,10 +76,12 @@ func logInit() {
 	log.SetOutput(os.Stdout)
 }
 
-func delay() {
+func delay(start time.Time) {
 	for x := 1; x <= 5; x++ {
 		time.Sleep(1 * time.Second)
 	}
+	stop := time.Now()
+	log.Infof("missionDuration: %v", stop.Sub(start).Round(time.Second))
 }
 
 func runProvider() {
@@ -90,7 +92,8 @@ func runProvider() {
 
 	// TODO dont do this
 	// wait a few seconds for all events to come through before ending
-	defer delay()
+	start := time.Now()
+	defer delay(start)
 
 	if deploymentType == "capv" {
 		vsProvider := vsphere.NewMgmtBootstrapCAPV(new(vsphere.MgmtBootstrapCAPV))
@@ -122,7 +125,6 @@ func runProvider() {
 		bootstrap = vsProvider
 	}
 
-	start := time.Now()
 	log.Info("Welcome to Mission Control")
 	log.WithFields(log.Fields{
 		"ClusterName":              clusterName,
@@ -145,9 +147,6 @@ func runProvider() {
 		log.Error("error encountered during bootstrap")
 		log.Fatal(err.Error())
 	}
-
-	stop := time.Now()
-	log.Infof("missionDuration: %v", stop.Sub(start).Round(time.Second))
 }
 
 func runEngine() {
@@ -158,6 +157,11 @@ func runEngine() {
 	var workerCount int
 	var logFile string
 	var engineName engine.Cluster
+
+	// TODO dont do this
+	// wait a few seconds for all events to come through before ending
+	start := time.Now()
+	defer delay(start)
 
 	if deploymentType == "capv" {
 		engine := capv.NewMgmtClusterCAPV()
@@ -228,7 +232,6 @@ func runEngine() {
 	mw := io.MultiWriter(os.Stdout, file)
 	log.SetOutput(mw)
 
-	start := time.Now()
 	log.Info("Welcome to Mission Control")
 	log.WithFields(log.Fields{
 		"ClusterName":              clusterName,
@@ -249,6 +252,4 @@ func runEngine() {
 	if err != nil {
 		log.Error(err.Error())
 	}
-	stop := time.Now()
-	log.Infof("missionDuration: %v", stop.Sub(start).Round(time.Second))
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -81,6 +81,11 @@ func runProvider() {
 	var controlPlaneCount int
 	var workerCount int
 	var bootstrap provider.Bootstrapper
+
+	// TODO dont do this
+	// wait a few seconds for all events to come through before ending
+	defer time.Sleep(5 * time.Second)
+
 	if deploymentType == "capv" {
 		vsProvider := vsphere.NewMgmtBootstrapCAPV(new(vsphere.MgmtBootstrapCAPV))
 		errJ := yaml.Unmarshal(specContents, &vsProvider)
@@ -135,9 +140,7 @@ func runProvider() {
 		log.Fatal(err.Error())
 	}
 
-	// TODO dont do this
-	// wait a few seconds for all events to come through before ending
-	time.Sleep(5 * time.Second)
+
 	stop := time.Now()
 	log.Infof("missionDuration: %v", stop.Sub(start).Round(time.Second))
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -76,6 +76,12 @@ func logInit() {
 	log.SetOutput(os.Stdout)
 }
 
+func delay() {
+	for x := 1; x <= 5; x++ {
+		time.Sleep(1 * time.Second)
+	}
+}
+
 func runProvider() {
 	var err error
 	var controlPlaneCount int
@@ -84,7 +90,7 @@ func runProvider() {
 
 	// TODO dont do this
 	// wait a few seconds for all events to come through before ending
-	defer time.Sleep(5 * time.Second)
+	defer delay()
 
 	if deploymentType == "capv" {
 		vsProvider := vsphere.NewMgmtBootstrapCAPV(new(vsphere.MgmtBootstrapCAPV))
@@ -139,7 +145,6 @@ func runProvider() {
 		log.Error("error encountered during bootstrap")
 		log.Fatal(err.Error())
 	}
-
 
 	stop := time.Now()
 	log.Infof("missionDuration: %v", stop.Sub(start).Round(time.Second))

--- a/pkg/engine/rkecli/rkecli.go
+++ b/pkg/engine/rkecli/rkecli.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
-	defaultConfigPath  = "/rke-config.yml"
-	defaultHostname    = "my.rancher.org"
-	certManagerCRDURL  = "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml"
-	certManagerVersion = "v0.12.0"
+	defaultConfigPath = "/rke-config.yml"
+	defaultHostname   = "my.rancher.org"
+	//certManagerCRDURL  = "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml"
+	certManagerCRDURL = "https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml"
+	//certManagerVersion = "v0.12.0"
+	certManagerVersion = "v0.15.0"
 )
 
 // NewMgmtClusterCli creates a new cluster interface with a full config from the client
@@ -115,6 +117,7 @@ func (c *MgmtCluster) CreatePermanent() error {
 		return fmt.Errorf("error unmarshaling RKE cluster config file: %s", err)
 	}
 
+	var sans []string
 	nodes := make([]*rkeConfigNode, 0)
 	for k, v := range c.Nodes {
 		node := &rkeConfigNode{
@@ -133,6 +136,7 @@ func (c *MgmtCluster) CreatePermanent() error {
 		}
 		if strings.HasPrefix(strings.ToLower(k), "controlplane") {
 			node.Role = append(node.Role, "controlplane")
+			sans = append(sans, v)
 		} else {
 			node.Role = append(node.Role, "worker")
 		}
@@ -155,6 +159,12 @@ func (c *MgmtCluster) CreatePermanent() error {
 
 	y["nodes"] = nodes
 	y["ssh_key_path"] = c.SSH.KeyPath
+	sans = append(sans, c.Hostname)
+	y["authentication"] = map[string]interface{}{
+		"sans":     sans,
+		"strategy": "x509",
+		"webhook":  nil,
+	}
 
 	clusterYML, err := yaml.Marshal(y)
 	if err != nil {
@@ -335,8 +345,7 @@ func (c MgmtCluster) PivotControlPlane() error {
 		fmt.Sprintf("%s/rancher", rVersion),
 		fmt.Sprintf("--namespace=%s", namespace),
 		fmt.Sprintf("--kubeconfig=%s", kubeConfigFile),
-		"--set",
-		fmt.Sprintf("hostname=%s", c.Hostname),
+		fmt.Sprintf("--set %s,%s", fmt.Sprintf("hostname=%s", c.Hostname), fmt.Sprintf("certmanager.version=%s", certManagerVersion)),
 	}
 	err = cmd.GenericExecute(nil, "helm", args, nil)
 	if err != nil {

--- a/pkg/engine/rkecli/rkecli.go
+++ b/pkg/engine/rkecli/rkecli.go
@@ -345,7 +345,8 @@ func (c MgmtCluster) PivotControlPlane() error {
 		fmt.Sprintf("%s/rancher", rVersion),
 		fmt.Sprintf("--namespace=%s", namespace),
 		fmt.Sprintf("--kubeconfig=%s", kubeConfigFile),
-		fmt.Sprintf("--set %s,%s", fmt.Sprintf("hostname=%s", c.Hostname), fmt.Sprintf("certmanager.version=%s", certManagerVersion)),
+		"--set",
+		fmt.Sprintf("%s,%s", fmt.Sprintf("hostname=%s", c.Hostname), fmt.Sprintf("certmanager.version=%s", certManagerVersion)),
 	}
 	err = cmd.GenericExecute(nil, "helm", args, nil)
 	if err != nil {

--- a/pkg/engine/rkecli/rkecli.go
+++ b/pkg/engine/rkecli/rkecli.go
@@ -19,11 +19,9 @@ import (
 )
 
 const (
-	defaultConfigPath = "/rke-config.yml"
-	defaultHostname   = "my.rancher.org"
-	//certManagerCRDURL  = "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml"
-	certManagerCRDURL = "https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml"
-	//certManagerVersion = "v0.12.0"
+	defaultConfigPath  = "/rke-config.yml"
+	defaultHostname    = "my.rancher.org"
+	certManagerCRDURL  = "https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml"
 	certManagerVersion = "v0.15.0"
 )
 

--- a/pkg/engine/rkecli/rkecli_test.go
+++ b/pkg/engine/rkecli/rkecli_test.go
@@ -1,0 +1,30 @@
+package rkecli
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestRKEconfig(t *testing.T) {
+	t.Skip("not ready for primetime yet")
+	var y map[string]interface{}
+	err := yaml.Unmarshal([]byte(rawClusterYML), &y)
+	if err != nil {
+		t.Errorf("error unmarshaling RKE cluster config file: %s", err)
+	}
+	fmt.Printf("before: %v\n", y)
+	y["authentication"] = map[string]interface{}{
+		"sans":     []string{"172.60.0.40", "my.rancher.org"},
+		"strategy": "x509",
+		"webhook":  nil,
+	}
+
+	fmt.Printf("after: %v\n", y)
+
+	_, err = yaml.Marshal(y)
+	if err != nil {
+		t.Errorf("error marshaling RKE cluster config file: %s", err)
+	}
+	//fmt.Println(string(clusterYML))
+}

--- a/pkg/engine/rkecli/types.go
+++ b/pkg/engine/rkecli/types.go
@@ -37,8 +37,6 @@ type rkeConfigNode struct {
 }
 
 type rkeTaint struct {
-	Key       string         `json:"key,omitempty" yaml:"key"`
-	Value     string         `json:"value,omitempty" yaml:"value"`
+	Key   string `json:"key,omitempty" yaml:"key"`
+	Value string `json:"value,omitempty" yaml:"value"`
 }
-
-


### PR DESCRIPTION
- update some formatting
- fix cert manager issue. It was not creating an issuer crd when helm installing rancher. This was because of a apiVersion mismatch for the `kind: Issuer` being too old. I added `--set certmanager.version=v0.15.0` to the helm install command to update the `kind: Issuer` to use the latest apiVersion.
- added additional sans (subject alternative names) to the rke kubeconfig to allow for it to be used by IP.