### PR TITLE
fix missing log lines on fatal exit from cli

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -90,10 +90,12 @@ func runProvider() {
 	var workerCount int
 	var bootstrap provider.Bootstrapper
 
-	// TODO dont do this
-	// wait a few seconds for all events to come through before ending
+	// TODO better way to wait for any final events
+	// wait a few seconds for all events to come through before exiting
 	start := time.Now()
-	defer delay(start)
+	log.DeferExitHandler(func() {
+		delay(start)
+	})
 
 	if deploymentType == "capv" {
 		vsProvider := vsphere.NewMgmtBootstrapCAPV(new(vsphere.MgmtBootstrapCAPV))
@@ -158,10 +160,12 @@ func runEngine() {
 	var logFile string
 	var engineName engine.Cluster
 
-	// TODO dont do this
-	// wait a few seconds for all events to come through before ending
+	// TODO better way to wait for any final events
+	// wait a few seconds for all events to come through before exiting
 	start := time.Now()
-	defer delay(start)
+	log.DeferExitHandler(func() {
+		delay(start)
+	})
 
 	if deploymentType == "capv" {
 		engine := capv.NewMgmtClusterCAPV()


### PR DESCRIPTION
use logrus.DeferExitHandler instead of builtin defer. this fixes issue https://github.com/NetApp/cake/issues/75, where log lines weren't being captured when the cli exits with a logrus fatal.